### PR TITLE
Corrected pager twig to replace hardcoded theme machine name.

### DIFF
--- a/generators/app/templates/_templates/navigation/pager.html.twig
+++ b/generators/app/templates/_templates/navigation/pager.html.twig
@@ -34,7 +34,7 @@
  *   likely change when that issue is completed.
  */
 #}
-{{ attach_library('imalabya/pager') }}
+{{ attach_library('<% themeMachineName %>/pager') }}
 {% if items %}
   <nav class="pager" aria-labelledby="{{ heading_id }}">
     <h4 id="{{ heading_id }}" class="visually-hidden">{{ 'Pagination'|t }}</h4>
@@ -44,7 +44,7 @@
         {% apply spaceless %}
         <li class="pager__item pager__item--first">
           <a href="{{ items.first.href }}" title="{{ 'Go to first page'|t }}"{{ items.first.attributes|without('href', 'title') }}>
-            {% include "@imalabya/svg/pager-first.html.twig" %}
+            {% include "@<% themeMachineName %>/svg/pager-first.html.twig" %}
             <span class="visually-hidden">{{ 'First page'|t }}</span>
           </a>
         </li>
@@ -56,7 +56,7 @@
         {% apply spaceless %}
         <li class="pager__item pager__item--previous">
           <a href="{{ items.previous.href }}" title="{{ 'Go to previous page'|t }}" rel="prev"{{ items.previous.attributes|without('href', 'title', 'rel') }}>
-            {% include "@imalabya/svg/pager-previous.html.twig" %}
+            {% include "@<% themeMachineName %>/svg/pager-previous.html.twig" %}
             <span class="visually-hidden">{{ 'Previous page'|t }}</span>
           </a>
         </li>
@@ -97,7 +97,7 @@
         {% apply spaceless %}
         <li class="pager__item pager__item--next">
           <a href="{{ items.next.href }}" title="{{ 'Go to next page'|t }}" rel="next"{{ items.next.attributes|without('href', 'title', 'rel') }}>
-            {% include "@imalabya/svg/pager-next.html.twig" %}
+            {% include "@<% themeMachineName %>/svg/pager-next.html.twig" %}
             <span class="visually-hidden">{{ 'Next page'|t }}</span>
           </a>
         </li>
@@ -109,7 +109,7 @@
         {% apply spaceless %}
         <li class="pager__item pager__item--last">
           <a href="{{ items.last.href }}" title="{{ 'Go to last page'|t }}"{{ items.last.attributes|without('href', 'title') }}>
-            {% include "@imalabya/svg/pager-last.html.twig" %}
+            {% include "@<% themeMachineName %>/svg/pager-last.html.twig" %}
             <span class="visually-hidden">{{ 'Last page'|t }}</span>
           </a>
         </li>


### PR DESCRIPTION
Hi @malabya 
Please check it.

After running the script theme got created successfully. But as soon as I enabled the theme, I found following warning message.
![image](https://user-images.githubusercontent.com/71934770/95451112-f07d2b00-0984-11eb-8bb8-7a40e1bfc9bd.png)

On debugging it, I found that pager.html.twig had hardcoded theme machine name.